### PR TITLE
1128. Number of Equivalent Domino Pairs

### DIFF
--- a/1128.NumberOfEquivalentDominoPairs.cpp
+++ b/1128.NumberOfEquivalentDominoPairs.cpp
@@ -1,0 +1,17 @@
+class Solution {
+public:
+    int numEquivDominoPairs(vector<vector<int>>& dominoes) {
+        unordered_map<int, int> count;
+        int res = 0;
+        
+        for (auto &d : dominoes) {
+            int a = d[0], b = d[1];
+            int key = min(a, b) * 10 + max(a, b);
+            
+            res += count[key];
+            count[key]++;
+        }
+        
+        return res;
+    }
+};


### PR DESCRIPTION
This PR adds the solution for Leetcode problem 1128: "Number of Equivalent Domino Pairs".

- Implemented in C++ following the style used in other solutions in the repository.
- File name: 1128.NumberOfEquivalentDominoPairs.cpp

## Approach  
We normalize each domino by representing it as (min, max), so that [1,2] and [2,1] map to the same key.  
We use a hash map to count how many times each normalized domino appears.  
For each new domino, the number of equivalent pairs increases by the count of that domino seen so far.  

## Intuition  
Two dominoes are equivalent if their numbers are the same regardless of order.  
Instead of comparing every domino pair (which would be O(n²)), we can group them by a normalized representation and count pairs incrementally.  

## Solution in Code  
```cpp
class Solution {
public:
    int numEquivDominoPairs(vector<vector<int>>& dominoes) {
        unordered_map<int, int> count;
        int res = 0;
        
        for (auto &d : dominoes) {
            int a = d[0], b = d[1];
            int key = min(a, b) * 10 + max(a, b);
            res += count[key];
            count[key]++;
        }
        
        return res;
    }
};
```

https://github.com/SjxSubham/Leetcode/issues/103
